### PR TITLE
fix naming macro for 1.8

### DIFF
--- a/macros/custom_naming_macros.sql
+++ b/macros/custom_naming_macros.sql
@@ -13,7 +13,12 @@
     ) -%}
     {% set node_name = node.name %}
     {% set split_name = node_name.split('__') %}
-    {{ split_name [1] | trim }}
+    
+    {% if split_name | length < 2 %}
+        {{ split_name [0] | trim }}
+    {% else %}
+        {{ split_name [1] | trim }}
+    {% endif %}
 {%- endmacro %}
 
 {% macro generate_tmp_view_name(model_name) -%}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-dbt-snowflake>=1.7,<1.8
+dbt-core>=1.8,<1.9
+dbt-snowflake>=1.8,<1.9
 protobuf==4.25.3


### PR DESCRIPTION
- Modify naming macro to handle how ephemeral view names are referenced in `dbt 1.8`

To test run the below (you may need to re-assign view perms to internal_dev as I was having issues with it in dev)

```
pip install -r requirements.txt
dbt clean
dbt deps
export DBT_PROFILES_DIR=~/.dbt
```

```
dbt run -s models/streamline/core/streamline__chainhead.sql -t dev
dbt run -s models/evm/streamline/silver/streamline__evm_blocks.sql -t dev
dbt run -s models/evm/streamline/silver/core/history/streamline__evm_blocks_history.sql -t dev
```

```
14:59:42  1 of 1 OK created sql view model streamline.chainhead .......................... [SUCCESS 1 in 2.10s]
15:01:21  1 of 1 OK created sql view model streamline.evm_blocks ......................... [SUCCESS 1 in 2.80s]
15:04:35  1 of 1 OK created sql view model streamline.evm_blocks_history ................. [SUCCESS 1 in 2.70s]
```