### PR TITLE
An 5724 jellyverse

### DIFF
--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -1,0 +1,17 @@
+SELECT 
+    block_timestamp,
+    tx_hash,
+    event_index,
+    origin_from_address as swapper,
+    contract_address,
+    event_name,
+    decoded_log:poolId::STRING as pool_id,
+    decoded_log:tokenIn::STRING as token_in,
+    decoded_log:tokenOut::STRING as token_out,
+    decoded_log:amountIn::NUMBER as amount_in,
+    decoded_log:amountOut::NUMBER as amount_out
+FROM sei.core_evm.ez_decoded_event_logs
+WHERE contract_address = LOWER('0xfb43069f6d0473b85686a85f4ce4fc1fd8f00875')
+AND event_name = 'Swap'
+AND tx_hash = '0x5c1852f9396b8dbcf41e7f8e028257628a43d51c482b0df921870177ac027c9a'
+ORDER BY event_index;

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'merge',
-    unique_key = 'pool_address',
+    unique_key = 'jellyswap_pools_id',
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['noncore']
 ) }}

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -37,11 +37,11 @@ created_pools AS (
         AND tx_status = 'SUCCESS'
     
     {% if is_incremental() %}
-        AND _inserted_timestamp >= (
+        AND modified_timestamp >= (
             SELECT
-                max_inserted_timestamp
+                MAX(modified_timestamp) - INTERVAL '5 minutes' AS max_inserted_timestamp
             FROM 
-                last_update
+                {{ this }}
         )
     {% endif %}
 )

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -39,7 +39,6 @@ SELECT
     tx_hash,
     event_index,
     contract_address,
-
     pool_id,
     pool_address,
     {{ dbt_utils.generate_surrogate_key(

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -6,7 +6,18 @@
     tags = ['noncore']
 ) }}
 
-WITH created_pools AS (
+WITH
+
+{% if is_incremental() %}
+    last_update AS (
+        SELECT
+            MAX(modified_timestamp) - INTERVAL '5 minutes' AS max_inserted_timestamp
+        FROM 
+            {{ this }}
+    ),
+{% endif %}
+
+created_pools AS (
     SELECT 
 
         block_number,
@@ -28,8 +39,9 @@ WITH created_pools AS (
     {% if is_incremental() %}
         AND _inserted_timestamp >= (
             SELECT
-                MAX(_inserted_timestamp) - INTERVAL '5 minutes'
-            FROM {{ this }}
+                max_inserted_timestamp
+            FROM 
+                last_update
         )
     {% endif %}
 )

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.sql
@@ -7,19 +7,8 @@
 ) }}
 
 WITH
-
-{% if is_incremental() %}
-    last_update AS (
-        SELECT
-            MAX(modified_timestamp) - INTERVAL '5 minutes' AS max_inserted_timestamp
-        FROM 
-            {{ this }}
-    ),
-{% endif %}
-
 created_pools AS (
     SELECT 
-
         block_number,
         block_timestamp,
         tx_hash,

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
@@ -20,8 +20,10 @@ models:
       - name: jellyswap_pools_id
         description: Unique identifier for the pool
         tests:
-          - unique
-          - not_null
+          - unique:
+              where: modified_timestamp > current_date -3
+          - not_null:
+              where: modified_timestamp > current_date -3
         
 
   

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
@@ -1,0 +1,34 @@
+version: 2
+models:
+  - name: silver_evm_dex__jellyswap_pools
+    description: Records of pools created on the jellyswap platform.
+    columns:
+      - name: BLOCK_NUMBER
+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+
+      - name: tx_hash
+
+      - name: event_index
+ 
+      - name: contract_address
+ 
+      - name: pool_id
+
+      - name: pool_address
+
+      - name: jellyswap_pools_id
+        description: Unique identifier for the pool
+        tests:
+          - unique
+          - not_null
+        
+
+  
+  
+
+

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_pools.yml
@@ -6,10 +6,6 @@ models:
       - name: BLOCK_NUMBER
 
       - name: BLOCK_TIMESTAMP
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
 
       - name: tx_hash
 

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.sql
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.sql
@@ -1,0 +1,69 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    unique_key = 'jellyswap_swaps_id',
+    merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['noncore']
+) }}
+
+WITH swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        l.event_index,
+        'Swap' AS event_name,
+        l.origin_function_signature,
+        l.origin_from_address,
+        l.origin_to_address,
+        l.contract_address,
+        topics[1]::STRING as pool_id,
+        CONCAT('0x', SUBSTR(topics[2]::STRING, 27, 40))::FLOAT as token_in,
+        CONCAT('0x', SUBSTR(topics[3]::STRING, 27, 40))::FLOAT as token_out,
+        regexp_substr_all(SUBSTR(data, 3, len(data)), '.{64}') AS segmented_data,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data[0]::STRING
+        ) as amount_in_raw,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data[1]::STRING
+        ) as amount_out_raw,
+        _inserted_timestamp
+    FROM 
+        {{ ref('silver_evm__logs') }} l
+    WHERE 
+        topics[0]::STRING = '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b' -- Swap event
+        AND pool_id IN (SELECT pool_id FROM {{ ref('silver_evm_dex__jellyswap_pools') }})
+        AND tx_status = 'SUCCESS'
+
+    {% if is_incremental() %}
+        AND l.modified_timestamp >= (
+            SELECT MAX(modified_timestamp) - INTERVAL '5 minutes'
+            FROM {{ this }}
+        )
+    {% endif %}
+)
+
+SELECT 
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    event_name,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_id,
+    token_in,
+    token_out,
+    amount_in_raw as amount_in_unadj,
+    amount_out_raw as amount_out_unadj,
+    {{ dbt_utils.generate_surrogate_key(['tx_hash', 'event_index']) }} AS jellyswap_swaps_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+    swaps_base

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.yml
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.yml
@@ -39,5 +39,7 @@ models:
       - name: jellyswap_swaps_id
         description: Unique identifier for the swap
         tests:
-          - unique
-          - not_null
+          - unique:
+              where: modified_timestamp > current_date -3
+          - not_null:
+              where: modified_timestamp > current_date -3

--- a/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.yml
+++ b/models/evm/silver/defi/dex/jellyswap/silver_evm_dex__jellyswap_swaps.yml
@@ -1,0 +1,43 @@
+version: 2
+models:
+  - name: silver_evm_dex__jellyswap_swaps
+    description: Records of swaps that occurred on the jellyswap platform
+    columns:
+      - name: BLOCK_NUMBER
+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+
+      - name: tx_hash
+
+      - name: event_index
+ 
+      - name: event_name
+ 
+      - name: origin_function_signature
+ 
+      - name: origin_from_address
+ 
+      - name: origin_to_address
+ 
+      - name: contract_address
+ 
+      - name: pool_id
+        description: Identifier from Jellyswap for the pool in which the swap occurred
+
+      - name: amount_in_unadj
+ 
+      - name: amount_out_unadj
+ 
+      - name: token_in
+
+      - name: token_out
+
+      - name: jellyswap_swaps_id
+        description: Unique identifier for the swap
+        tests:
+          - unique
+          - not_null

--- a/models/evm/silver/defi/dex/silver_evm_dex__swaps_combined.sql
+++ b/models/evm/silver/defi/dex/silver_evm_dex__swaps_combined.sql
@@ -50,12 +50,41 @@ WHERE
     modified_timestamp >= '{{ max_mod_timestamp }}'
 {% endif %}
 
-qualify ROW_NUMBER() over (
-    PARTITION BY tx_hash,
-    event_index
-    ORDER BY
-        modified_timestamp DESC
-) = 1 -- add other dexes
+    qualify ROW_NUMBER() over (
+        PARTITION BY tx_hash,
+        event_index
+        ORDER BY
+            modified_timestamp DESC
+    ) = 1 -- add other dexes
+
+    UNION ALL
+
+    SELECT
+        'jellyswap' AS platform,
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        event_name,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        pool_address AS contract_address,
+        null AS tx_to,
+        null AS sender,
+        amount_in_unadj,
+        amount_out_unadj,
+        token_in,
+        token_out,
+        jellyswap_swaps_id AS uk
+
+    FROM
+        {{ ref('silver_evm_dex__jellyswap_swaps') }}
+
+{% if is_incremental() and 'dragonswap' not in var('HEAL_MODELS') %}
+WHERE
+    modified_timestamp >= '{{ max_mod_timestamp }}'
+{% endif %}
 )
 
 {% if is_incremental() %},


### PR DESCRIPTION
Adds models to track Jellyswap pools and swaps using event logs from the protocol's Vault contract. Implements pool ID tracking and swap amount calculations with raw hex values for verification.

Swap labeling logic: fetch `pool_id` from all tx on `contract_address = 'Vault'` and `event_name = 'Swap'` -> find all the swaps happening on that `pool_id` from the raw `logs` table